### PR TITLE
Ported to use MechanicalSoup for Python 3 compatibility

### DIFF
--- a/kaggle_cli/common.py
+++ b/kaggle_cli/common.py
@@ -1,0 +1,83 @@
+from configparser import ConfigParser
+from mechanicalsoup import Browser
+import os
+import sys
+
+def get_config(parsed_args):
+    prefix = ''
+    while True:
+        config_dir = '.kaggle-cli'
+        if os.path.isdir(prefix + config_dir) or \
+            os.path.abspath(prefix) == os.path.expanduser('~') or \
+                os.path.abspath(prefix) == os.path.abspath('/'):
+            break
+        prefix = prefix + '../'
+
+    config_dir = os.path.abspath(prefix + config_dir)
+
+    global_config_dir = '~/.kaggle-cli'
+    global_config_dir = os.path.expanduser(global_config_dir)
+
+    if os.path.isdir(global_config_dir):
+        global_config = ConfigParser(allow_no_value=True)
+        global_config.readfp(open(global_config_dir + '/config'))
+
+        if parsed_args.username:
+            username = parsed_args.username
+        else:
+            username = global_config.get('user', 'username')
+
+        if parsed_args.password:
+            password = parsed_args.password
+        else:
+            password = global_config.get('user', 'password')
+
+        if parsed_args.competition:
+            competition = parsed_args.competition
+        else:
+            competition = global_config.get('user', 'competition')
+
+    if os.path.isdir(config_dir):
+        config = ConfigParser(allow_no_value=True)
+        config.readfp(open(config_dir + '/config'))
+
+        if parsed_args.username:
+            username = parsed_args.username
+        else:
+            if config.has_option('user', 'username'):
+                username = config.get('user', 'username')
+
+        if parsed_args.password:
+            password = parsed_args.password
+        else:
+            if config.has_option('user', 'password'):
+                password = config.get('user', 'password')
+
+        if parsed_args.competition:
+            competition = parsed_args.competition
+        else:
+            if config.has_option('user', 'competition'):
+                competition = config.get('user', 'competition')
+    else:
+        username = parsed_args.username
+        password = parsed_args.password
+        competition = parsed_args.competition
+
+    return (username, password, competition)
+
+def login(username, password):
+    login_url = 'https://www.kaggle.com/account/login'
+    browser = Browser()
+
+    login_page = browser.get(login_url)
+    login_form = login_page.soup.select("#login-account")[0]
+    login_form.select("#UserName")[0]['value'] = username
+    login_form.select("#Password")[0]['value'] = password
+    login_result = browser.submit(login_form, login_page.url)
+    if login_result.url == login_url:
+        error = (login_result.soup
+                .select('#standalone-signin .validation-summary-errors')[0].get_text())
+        print('There was an error logging in: ' + error)
+        sys.exit(1)
+
+    return browser

--- a/kaggle_cli/config.py
+++ b/kaggle_cli/config.py
@@ -1,5 +1,5 @@
 from cliff.command import Command
-import ConfigParser
+from configparser import ConfigParser
 import os
 
 
@@ -45,7 +45,7 @@ class Config(Command):
             else:
                 config_dir = prefix + config_dir
 
-        config = ConfigParser.ConfigParser(allow_no_value=True)
+        config = ConfigParser(allow_no_value=True)
 
         if os.path.isfile(config_dir + '/config'):
             config.readfp(open(config_dir + '/config'))

--- a/kaggle_cli/submit.py
+++ b/kaggle_cli/submit.py
@@ -1,10 +1,6 @@
 from cliff.command import Command
-from mechanize import Browser
-from lxml import html
 from time import sleep
-import os
-import ConfigParser
-
+from . import common
 
 class Submit(Command):
     'Submit an entry to a specific competition.'
@@ -22,91 +18,24 @@ class Submit(Command):
         return parser
 
     def take_action(self, parsed_args):
-        prefix = ''
-        while True:
-            config_dir = '.kaggle-cli'
-            if os.path.isdir(prefix + config_dir) or \
-                os.path.abspath(prefix) == os.path.expanduser('~') or \
-                    os.path.abspath(prefix) == os.path.abspath('/'):
-                break
-            prefix = prefix + '../'
-
-        config_dir = os.path.abspath(prefix + config_dir)
-
-        global_config_dir = '~/.kaggle-cli'
-        global_config_dir = os.path.expanduser(global_config_dir)
-
-        if os.path.isdir(global_config_dir):
-            global_config = ConfigParser.ConfigParser(allow_no_value=True)
-            global_config.readfp(open(global_config_dir + '/config'))
-
-            if parsed_args.username:
-                username = parsed_args.username
-            else:
-                username = global_config.get('user', 'username')
-
-            if parsed_args.password:
-                password = parsed_args.password
-            else:
-                password = global_config.get('user', 'password')
-
-            if parsed_args.competition:
-                competition = parsed_args.competition
-            else:
-                competition = global_config.get('user', 'competition')
-
-        if os.path.isdir(config_dir):
-            config = ConfigParser.ConfigParser(allow_no_value=True)
-            config.readfp(open(config_dir + '/config'))
-
-            if parsed_args.username:
-                username = parsed_args.username
-            else:
-                if config.has_option('user', 'username'):
-                    username = config.get('user', 'username')
-
-            if parsed_args.password:
-                password = parsed_args.password
-            else:
-                if config.has_option('user', 'password'):
-                    password = config.get('user', 'password')
-
-            if parsed_args.competition:
-                competition = parsed_args.competition
-            else:
-                if config.has_option('user', 'competition'):
-                    competition = config.get('user', 'competition')
-        else:
-            username = parsed_args.username
-            password = parsed_args.password
-            competition = parsed_args.competition
+        (username, password, competition) = common.get_config(parsed_args)
+        browser = common.login(username, password)
 
         base = 'https://www.kaggle.com'
-        login_url = 'https://www.kaggle.com/account/login'
         submit_url = '/'.join([base, 'c', competition, 'submissions', 'attach'])
 
         entry = parsed_args.entry
         message = parsed_args.message
 
-        browser = Browser()
-
-        browser.open(login_url)
-        browser.select_form(nr=0)
-
-        browser['UserName'] = username
-        browser['Password'] = password
-
-        browser.submit()
-
-        browser.open(submit_url)
-        browser.select_form(nr=0)
-
-        browser.form.add_file(open(entry), filename=entry)
+        submit_page = browser.get(submit_url)
+        submit_form = submit_page.soup.find(id='submission-form')
+        submit_form.find('input', {'name': 'SubmissionUpload'})['value'] = entry
 
         if message:
-            browser['SubmissionDescription'] = message
-
-        browser.submit()
+            submit_form.find('textarea', {'name': 'SubmissionDescription'}).insert(0, message)
+        submit_result = browser.submit(submit_form, submit_page.url)
+        leaderboard_url = '/'.join([base, 'c', competition, 'leaderboard'])
+        assert submit_result.url == leaderboard_url
 
         # while True:
         #     leaderboard = html.fromstring(browser.response().read())

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     scripts=[],
 
     provides=[],
-    install_requires=['cliff', 'mechanize', 'lxml', 'cssselect'],
+    install_requires=['cliff', 'MechanicalSoup', 'lxml', 'cssselect', 'configparser'],
 
     namespace_packages=[],
     packages=find_packages(),


### PR DESCRIPTION
Mechanizer is not compatible with Python 3. This change ports the
library to a similar library that doesn't have this problem.