### PR TITLE
Adding Progress bar to the downloads

### DIFF
--- a/kaggle_cli/download.py
+++ b/kaggle_cli/download.py
@@ -51,24 +51,23 @@ class Download(Command):
         done = False
         file_size = 0
         total_size = 0
-        bar = progressbar.ProgressBar()
 
-        if os.path.isfile(local_filename):
->>>>>>> upstream/master
+        bar = progressbar.ProgressBar()
+        content_length = int(
+            browser.request('head', url).headers.get('Content-Length')
+        )
 
         if os.path.isfile(local_filename):
             file_size = os.path.getsize(local_filename)
-            content_length = int(
-                browser.request('head', url).headers.get('Content-Length')
-            )
             if file_size < content_length:
                 headers['Range'] = 'bytes={}-'.format(file_size)
             else:
                 done = True
 
         self.bytes = file_size
-        widgets = [local_filename, ' ', progressbar.Percentage(), ' ', progressbar.Bar(marker="#"),
-               ' ', progressbar.ETA(), ' ', progressbar.FileTransferSpeed()]
+        widgets = [local_filename, ' ', progressbar.Percentage(), ' ',
+                  progressbar.Bar(marker="#"), ' ',
+                  progressbar.ETA(), ' ', progressbar.FileTransferSpeed()]
 
         if file_size == content_length:
             print('{} already downloaded !'.format(local_filename))
@@ -77,7 +76,8 @@ class Download(Command):
             print("Something wrong here, Incorrect file !")
             return
         else :
-            bar = progressbar.ProgressBar(widgets=widgets, maxval=content_length).start()
+            bar = progressbar.ProgressBar(widgets=widgets, 
+                                          maxval=content_length).start()
             if not self.bytes:
                 bar.update(self.bytes)
 

--- a/kaggle_cli/download.py
+++ b/kaggle_cli/download.py
@@ -6,6 +6,8 @@ from cliff.command import Command
 from . import common
 from .config import get_final_config
 
+import progressbar
+from contextlib import closing
 
 class Download(Command):
     'Download data files from a specific competition.'
@@ -46,12 +48,34 @@ class Download(Command):
         self.app.stdout.write('downloading %s\n' % url)
         local_filename = url.split('/')[-1]
         headers = {}
+        file_size = 0
+        total_size = 0
+        bar = progressbar.ProgressBar()
 
         if os.path.isfile(local_filename):
             file_size = os.path.getsize(local_filename)
             headers['Range'] = 'bytes={}-'.format(file_size)
 
+        with closing(browser.get(url, stream=True)) as stream_orig:
+            total_size = int(stream_orig.headers['Content-Length'].strip())
+
+        self.bytes = file_size
+
         stream = browser.get(url, stream=True, headers=headers)
+
+        widgets = [local_filename,' ',progressbar.Percentage(),' ', progressbar.Bar(marker="#"),
+               ' ', progressbar.ETA(), ' ', progressbar.FileTransferSpeed()]
+
+        if file_size == total_size:
+            print local_filename+" already downloaded !"
+            return local_filename
+        elif file_size > total_size :
+            print "Something wrong here, Incorrect file !"
+            return
+        else :
+            bar = progressbar.ProgressBar(widgets = widgets, maxval=total_size).start()
+            if not self.bytes:
+                bar.update(self.bytes)
 
         if stream.headers.get('x-ms-copy-status', None) == 'success':
             if not self.is_downloadable(stream):
@@ -63,6 +87,9 @@ class Download(Command):
                 for chunk in stream.iter_content(chunk_size=1024, decode_unicode=True):
                     if chunk: # filter out keep-alive new chunks
                         f.write(chunk)
+                        self.bytes += len(chunk)
+                        bar.update(self.bytes)
+            bar.finish()
 
     def is_downloadable(self, response):
         """


### PR DESCRIPTION
This patch will add progress bar to data downloads and supports the continuation of the progress meter from where we left earlier, if we resume download. 

It'll show the file being downloaded, percentage, adaptive ETA during download, elasped time and the data transfer speed.

![addprogressbar](https://cloud.githubusercontent.com/assets/25096842/24076726/16982966-0c5e-11e7-80ed-e6af63a446a6.jpg)


