### PR TITLE
The condition for while in config.py was changed.

### DIFF
--- a/kaggle_cli/config.py
+++ b/kaggle_cli/config.py
@@ -23,7 +23,8 @@ def get_config(config_path):
 
 
 def get_config_candidates(curdir):
-    while curdir != '/':
+    prevdir = ''
+    while curdir != prevdir:
         if curdir != os.path.expanduser('~'):
             config_path = os.path.join(
                 curdir, CONFIG_DIR_NAME, CONFIG_FILE_NAME
@@ -31,6 +32,7 @@ def get_config_candidates(curdir):
             config = get_config(config_path)
             if config:
                 yield config
+        prevdir = curdir
         curdir = os.path.dirname(curdir)  # derive parent dir
 
     config_path = os.path.join(


### PR DESCRIPTION
I found kaggle-cli doesn't work on Windows.  Procedure get caught in an endless loop in get_config_candidates() in config.py. 
This is because  the condition `curdir != '/'` for while loop in get_config_candidates doesn't work on Windows, because `'/'` doesn't match with Windows' root directory.
In Windows os, root directory is not always the same, since there are some drives such as C:, D:.  So I suggest that the while loop is broken when curdir is not changed.