### PR TITLE
add --zip option to zip the submission file prior to uploading it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 */__pycache__/
 */*.pyc
 .kaggle-cli
+.idea/

--- a/kaggle_cli/config.py
+++ b/kaggle_cli/config.py
@@ -5,10 +5,9 @@ from itertools import starmap
 
 from cliff.command import Command
 
-
 CONFIG_DIR_NAME = '.kaggle-cli'
 CONFIG_FILE_NAME = 'config'
-DATA_OPTIONS = set(['username', 'password', 'competition'])
+DATA_OPTIONS = set(['username', 'password', 'competition', 'zip'])
 
 
 def get_config(config_path):
@@ -85,6 +84,7 @@ class Config(Command):
         parser.add_argument('-u', '--username', help='username')
         parser.add_argument('-p', '--password', help='password')
         parser.add_argument('-c', '--competition', help='competition')
+        parser.add_argument('-z', '--zip', help='zip the submission file before uploading?', action='store_true')
         parser.add_argument(
             '-g',
             '--global',
@@ -98,7 +98,7 @@ class Config(Command):
         parsed_arg_dict = vars(parsed_args)
 
         if DATA_OPTIONS & set(
-            filter(lambda x: parsed_arg_dict[x], parsed_arg_dict)
+                filter(lambda x: parsed_arg_dict[x], parsed_arg_dict)
         ):
             if parsed_arg_dict['global']:
                 config_dir = os.path.join(
@@ -134,6 +134,11 @@ class Config(Command):
                     'user', 'competition',
                     parsed_arg_dict['competition']
                 )
+
+            if parsed_arg_dict['zip']:
+                config.set('user', 'zip', 'yes')
+            else:
+                config.set('user', 'zip', 'no')
 
             with open(config_path, 'w') as config_file:
                 config.write(config_file)

--- a/kaggle_cli/submit.py
+++ b/kaggle_cli/submit.py
@@ -25,7 +25,7 @@ class Submit(Command):
         parser.add_argument('-u', '--username', help='username')
         parser.add_argument('-p', '--password', help='password')
         parser.add_argument('-z', '--zip', type=self._str2bool, nargs='?', const=True, default=False,
-                            help='zip the submission file before uploading')
+                            help='whether to zip the submission file before uploading')
 
         return parser
 
@@ -35,7 +35,12 @@ class Submit(Command):
         username = config.get('username', '')
         password = config.get('password', '')
         competition = config.get('competition', '')
-        zip = config.get('zip', False)
+        zip_flag = config.get('zip', 'no')
+
+        if Submit._str2bool(zip_flag):
+            zip = True
+        else:
+            zip = False
 
         browser = common.login(username, password)
         base = 'https://www.kaggle.com'
@@ -46,7 +51,7 @@ class Submit(Command):
         entry = parsed_args.entry
         message = parsed_args.message
 
-        archive_name = Submit._rand_str(10)+'.zip'
+        archive_name = Submit._rand_str(10) + '.zip'
 
         if zip:
             with zipfile.ZipFile(archive_name, 'w', zipfile.ZIP_DEFLATED) as zf:
@@ -122,10 +127,11 @@ class Submit(Command):
     @staticmethod
     def _str2bool(v):
         """
-        parse boolean values
+        parse truthy/falsy strings into booleans
 
         https://stackoverflow.com/a/43357954/436721
-        :return:
+        :param v: the string to be parsed
+        :return: a boolean value
         """
         if v.lower() in ('yes', 'true', 't', 'y', '1'):
             return True
@@ -136,4 +142,12 @@ class Submit(Command):
 
     @staticmethod
     def _rand_str(length):
-        return uuid.uuid4().hex[:length-1]
+        """
+        this is used to prevent caching issues
+
+        https://stackoverflow.com/a/34017605/436721
+
+        :param length: integer length
+        :return: a random string of the given length
+        """
+        return uuid.uuid4().hex[:length - 1]

--- a/kaggle_cli/submit.py
+++ b/kaggle_cli/submit.py
@@ -2,6 +2,9 @@ import os
 import time
 import re
 import json
+import uuid
+from argparse import ArgumentTypeError
+import zipfile
 
 from cliff.command import Command
 
@@ -21,6 +24,8 @@ class Submit(Command):
         parser.add_argument('-c', '--competition', help='competition')
         parser.add_argument('-u', '--username', help='username')
         parser.add_argument('-p', '--password', help='password')
+        parser.add_argument('-z', '--zip', type=self._str2bool, nargs='?', const=True, default=False,
+                            help='zip the submission file before uploading')
 
         return parser
 
@@ -30,6 +35,7 @@ class Submit(Command):
         username = config.get('username', '')
         password = config.get('password', '')
         competition = config.get('competition', '')
+        zip = config.get('zip', False)
 
         browser = common.login(username, password)
         base = 'https://www.kaggle.com'
@@ -39,6 +45,12 @@ class Submit(Command):
 
         entry = parsed_args.entry
         message = parsed_args.message
+
+        archive_name = Submit._rand_str(10)+'.zip'
+
+        if zip:
+            with zipfile.ZipFile(archive_name, 'w', zipfile.ZIP_DEFLATED) as zf:
+                zf.write(entry)
 
         competition_page = browser.get(competition_url)
 
@@ -51,18 +63,23 @@ class Submit(Command):
             str(competition_page.soup)
         ).group(1)
 
+        if zip:
+            target_name = archive_name
+        else:
+            target_name = entry
+
         form_submission = browser.post(
             file_form_submit_url,
             data={
-                'fileName': entry,
-                'contentLength': os.path.getsize(entry),
-                'lastModifiedDateUtc': int(os.path.getmtime(entry) * 1000)
+                'fileName': target_name,
+                'contentLength': os.path.getsize(target_name),
+                'lastModifiedDateUtc': int(os.path.getmtime(target_name) * 1000)
             }
         ).json()
 
         file_submit_url = base + form_submission['createUrl']
 
-        with open(entry, 'rb') as submission_file:
+        with open(target_name, 'rb') as submission_file:
             token = browser.post(
                 file_submit_url,
                 files={
@@ -98,3 +115,25 @@ class Submit(Command):
             else:
                 print('something went wrong')
                 break
+
+        if zip:
+            os.remove(target_name)
+
+    @staticmethod
+    def _str2bool(v):
+        """
+        parse boolean values
+
+        https://stackoverflow.com/a/43357954/436721
+        :return:
+        """
+        if v.lower() in ('yes', 'true', 't', 'y', '1'):
+            return True
+        elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+            return False
+        else:
+            raise ArgumentTypeError('Boolean value expected.')
+
+    @staticmethod
+    def _rand_str(length):
+        return uuid.uuid4().hex[:length-1]


### PR DESCRIPTION
If option is passed, a zip file is created (using pyhon zipfile module) with a random name (cache busting) and the zipped file is uploaded instead, to use less bandwidth. The zip file is deleted afterwards to avoid using up too much disk.