### PR TITLE
Up bs4 required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         'lxml>=4.0.0,<4.1',
         'cssselect>=1.0.1,<1.1',
         'configparser',
-        'progressbar2>=3.34.3,<3.35'
+        'progressbar2>=3.34.3,<3.35',
+        'beautifulsoup4>=4.6.0'
     ],
 
     namespace_packages=[],


### PR DESCRIPTION
Kaggle-cli uses bs4, but it is not in required packages list. Not worked for me before update bs4 to the latest version.