### PR TITLE
lxml package: allow latest release version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         'cliff>=2.8.0,<2.9',
         'MechanicalSoup>=0.7.0,<0.9',
-        'lxml>=4.0.0,<4.1',
+        'lxml>=4.0.0,<=4.2.1',
         'cssselect>=1.0.1,<1.1',
         'configparser',
         'progressbar2>=3.34.3,<3.35',


### PR DESCRIPTION
lxml package: allow latest release version 4.2.1 from 2018-03-21

Hi!
I ran into problems when installing kaggle-cli inside the [fast.ai library](https://github.com/fastai/fastai), specifically: ```kaggle-cli 0.12.13 has requirement lxml<4.1,>=4.0.0, but you'll have lxml 4.2.1 which is incompatible.```

I couldn't find a reason why the lxml was fixed to a version previous to 4.1. If there is one maybe you can mention it here, otherwise it would be great if you can merge this PR.

Let me know if there is any more information you need or other work to do for this.
Thanks! :)